### PR TITLE
use proper Stata ouptut syntax and only format errors as errors

### DIFF
--- a/src/ado/reprun.ado
+++ b/src/ado/reprun.ado
@@ -128,21 +128,9 @@ qui {
     file close `h_smcl'
 
     if "`mmmflag'" != "" {
-      di as err "  Warning: Your code contains many-to-many merges."
-      di as err "  These occur on lines:`mmmflag'."
-      di as err ""
-      di as err "  The following is copied word-for-word from the documentation"
-      di as err "    of the merge command in the Stata Data Management Reference Manual."
-      di as err ""
-      di as err "    m:m specifies a many-to-many merge and is a bad idea."
-      di as err "    In an m:m merge, observations are matched within equal values of the key variable(s),"
-      di as err "      with the first observation being matched to the first; the second, to the second; and so on."
-      di as err "    If the master and using have an unequal number of observations within the group,"
-      di as err "      then the last observation of the shorter group is used repeatedly"
-      di as err "      to match with subsequent observations of the longer group."
-      di as err "    Thus m:m merges are dependent on the current sort order—something which should never happen.""
-      di as err "    Because m:m merges are such a bad idea, we are not going to show you an example."
-      di as err "    If you think that you need an m:m merge, then you probably need to work with your data so that you can use a 1:m or m:1 merge."
+      noi di as text _n "{pstd}{red:Warning:} Your code contains many-to-many merges. This occur on line(s):`mmmflag'.{p_end}" _n
+      noi di as text "{pstd}Reconsider using this approach as even Stata's documnetation discurages its usage. The following is copied word-for-word from the documentation of the merge command in the Stata Data Management Reference Manual:{p_end}" _n
+      noi di as text "{pmore}{it:m:m specifies a many-to-many merge and is a bad idea. In an m:m merge, observations are matched within equal values of the key variable(s), with the first observation being matched to the first; the second, to the second; and so on. If the master and using have an unequal number of observations within the group, then the last observation of the shorter group is used repeatedly to match with subsequent observations of the longer group. Thus m:m merges are dependent on the current sort order—something which should never happen. Because m:m merges are such a bad idea, we are not going to show you an example. If you think that you need an m:m merge, then you probably need to work with your data so that you can use a 1:m or m:1 merge.}{p_end}"
     }
 
   /*****************************************************************************


### PR DESCRIPTION
This makes this text display correctly regardless if screen size and settings.

@bbdaniels , do we have a reference for this as we claim this is what Stata says.  I find this in the documentation, which is similar but not word by word:

> merge m:m varlist ... specifies a many-to-many match merge. This is allowed for completeness, but it is difficult to imagine an example of when it would be useful. For an m:m merge, varlist does not uniquely identify the observations in either dataset. Matching is performed by combining observations with equal values of varlist; within matching values, the first observation in the master dataset is matched with the first matching observation in the using dataset; the second, with the second; and so on. If there is an unequal number of observations within a group, then the last observation of the shorter group is used repeatedly to