### PR TITLE
Fixes to reproot before Stata conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ src/dev/ssc
 src/tests/outputs/
 !/**/repadolog/**/stata.trk
 !/**/repadolog/**/repadolog.csv
+/**/reproot_setup/**/*.yaml
 
 * Ignore the local dev env set up by repado
 src/tests/dev-env/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Currently, this toolkit has the following commands:
 | [repadolog](https://worldbank.github.io/repkit/reference/repadolog.html) | Outputs a report of what commands are installed in the PLUS folder. |
 | [repkit](https://worldbank.github.io/repkit/reference/repkit.html) | Command named the same as the package. Most important purpose is that this command makes the code `which repkit` work. |
 | [reproot](https://worldbank.github.io/repkit/reference/reproot.html) | This command allows teams to dynamically set root-paths with no manual user-specific set-up, in both single-rooted and multi-rooted projects. |
+| [reproot_setup](https://worldbank.github.io/repkit/reference/reproot_setup.html) | This command helps setting up the environment setting file used in `reproot` |
 | [reprun](https://worldbank.github.io/repkit/reference/reprun.html) | This command is used to automate reproducibility checks by running a do-file or a set of do-files and compare all state values (RNG-value, datasignature etc.) between the two runs. This command is currently only release as a beta-version. |
 
 # Installation

--- a/src/ado/reproot.ado
+++ b/src/ado/reproot.ado
@@ -238,8 +238,6 @@ cap program drop   validate_global_name
 
     syntax, gname(string)
 
-    noi di as error `"gname [`gname']"'
-
     * Create a test value to be stored
     local test_value = "test-repkit-%-1234"
 

--- a/src/ado/reproot.ado
+++ b/src/ado/reproot.ado
@@ -8,7 +8,7 @@ qui {
     version 14.1
 
     * Update the syntax. This is only a placeholder to make the command run
-    syntax , Project(string) Roots(string) [prefix(string) clear]
+    syntax , Project(string) Roots(string) [OPTRoots(string) prefix(string) clear verbose]
 
     noi di _n "{hline}"
 
@@ -24,20 +24,41 @@ qui {
       Test if all roots are already loaded
     ***************************************************/
 
+    * List of all roots - required or optional
+    local all_roots : list roots | optroots
+
     local roots_set ""
     local roots_notset ""
 
     * If clear is used, then add all roots to roots_notset,
     * and search for all of them again
     if !missing("`clear'") {
-      local roots_notset "`roots'"
+      local roots_notset "`all_roots'"
     }
 
     * If clear is not used, test what root globals are already set,
     * and search only for roots not already set in root globals
     else {
-        * Test which roots if any are already loaded
-      foreach root of local roots {
+
+      /***************************************************
+        Test that all roots to look for has legal names
+      ***************************************************/
+      foreach root of local all_roots {
+        validate_global_name, rootname(`"`root'"') prefix("`prefix'")
+        if r(is_legal_name) == 0 {
+          local illegal_names `"`illegal_names' `prefix'`root'"'
+        }
+      }
+      if !missing(`"`illegal_names'"') {
+        local illegal_names = trim(`"`illegal_names'"')
+        if !missing("`prefix'") local prefix_str "with prefix "
+        noi di as error `"{phang}The following root global names`prefix_str' are not valid global names [`illegal_names']. Stata does not share an exhaustive documentation for legal global names, but these names failed our test. Even though some non-standard English letters are allowed, try to only use standard English letters and numbers. Underscores "_" may be used, but may not be the first character. Do not use any other special characters.{p_end}"' _n
+        error 198
+        exit
+      }
+
+      * Test which roots if any are already loaded
+      foreach root of local all_roots {
         * Test if root exists with prefix
         if missing("${`prefix'`root'}") {
           local roots_notset : list roots_notset | root
@@ -70,22 +91,6 @@ qui {
 
     * There are roots to search for
     else {
-
-      /***************************************************
-        Test that all roots to look for has legal names
-      ***************************************************/
-      foreach root of local roots_notset {
-        validate_global_name, gname(`"`root'"')
-        if r(is_legal_name) == 0 {
-          local illegal_names `"`illegal_names' `root'"'
-        }
-      }
-      if !missing(`"`illegal_names'"') {
-        local illegal_names = trim(`"`illegal_names'"')
-        noi di as error `"{phang}The following root global names are not valid global names [`illegal_names']. Stata does not share an exhaustive documentation for legal global names, but these names failed our test. Even though some non-standard English letters are allowed, try to only use standard English letters and numbers. Underscores "_" may be used, but may not be the first character. Do not use any other special characters.{p_end}"' _n
-        error 198
-        exit
-      }
 
     /***************************************************
       Output that at least some roots were not loaded
@@ -144,7 +149,7 @@ qui {
 
         * Output this search
         noi di_search_results, ///
-          time(`time') dcount(`dirs') rootdirs(`"`this_rootdirs'"')
+          time(`time') dcount(`dirs') rootdirs(`"`this_rootdirs'"') `verbose'
 
         * Add these rootdirs to the list of all dirs
         local rootdirs = trim(`"`rootdirs' `this_rootdirs'"')
@@ -154,10 +159,13 @@ qui {
         local tot_dirs = `tot_dirs' + `dirs'
       }
 
+      * Deduplicate the list in case the same root was found in multiple paths
+      local rootdirs : list uniq rootdirs
+
       * Output the grand total
       noi di as smcl `"{hline}"'
       noi di_search_results, total ///
-        time(`tot_time') dcount(`tot_dirs') rootdirs(`"`rootdirs'"')
+        time(`tot_time') dcount(`tot_dirs') rootdirs(`"`rootdirs'"') `verbose'
       noi di as smcl `"{hline}"'
 
 
@@ -165,41 +173,55 @@ qui {
         Parse the root files
       ***************************************************/
 
+      * List of roots found for this project
       local found_roots ""
 
+      * Parse all rootfile and filter out roots for this project
       foreach rootdir of local rootdirs {
+
+        * parse this root
         reproot_parse root, file("`rootdir'/`root_file'")
-        local this_root         "`r(root)'"
-        local this_root_global  "`prefix'`this_root'"
-        local this_root_project "`r(project)'"
+        local root = "`r(root)'"
 
-        * Test if this root belongs the relevant project
-        if "`project'" == "`this_root_project'" {
+        * Filter for this project and roots
+        if "`project'" == "`r(project)'" & `:list root in all_roots'  {
 
-          * Test if root was already found, if not then add to found_roots
-          if (`: list this_root in found_roots') {
-            noi di as error _n "{pstd}A second root called {result:`this_root)'} was found for this project found in folder {result:`rootdir'}.{p_end}"
-            error 99
+          *Test if root is duplicates
+          if (`:list root in found_roots') {
+            noi di as error `"{phang}Duplicate root found for root name [`root']. This root was found at [{it:`rootdir'}] after it had already been found at [{it:```prefix'`root'''}]. All roots must have a unique name within a project. No root globals were set.{p_end}"' _n
+            error 198
             exit
           }
-          local found_roots : list found_roots | this_root
-          noi di "found_roots `found_roots'"
 
-          local found_str "Root {result:`this_root'} for project {result:`this_root_project'} found"
-
-
-          if (`: list this_root in roots') {
-            * Output that a relevant root has been found
-            noi di _n as text "{pstd}`found_str'. Setting global {result:{c S|}{c -(}`this_root_global'{c )-}} to: {result:`rootdir'}{p_end}"
-
-            global `this_root_global' "`rootdir'"
-          }
-          * Root not required - just skip it
-          else {
-            noi di _n as text "{pstd}`found_str', but root not required, so no global is set for this root.{p_end}"
-          }
+          * Add root to found root and set local with this root's path
+          local found_roots "`found_roots' `root'"
+          tempname `prefix'`root'
+          local   ``prefix'`root'' "`rootdir'"
         }
       }
+
+      * Test that all required roots are found
+      local required_roots_not_found : list roots - found_roots
+      if !missing("`required_roots_not_found'") {
+        noi di as error _n `"{phang}The following required root(s) [`required_roots_not_found'] were not found. No root globals were set.{p_end}"'
+        error 198
+        exit
+      }
+
+      * Display what optional roots were not found
+      local optional_roots_not_found : list optroots - found_roots
+      if !missing("`optional_roots_not_found'") {
+        noi di as text _n `"{phang}The following optional root(s) [`optional_roots_not_found'] were not found.{p_end}"'
+      }
+
+      * Set all roots
+      foreach root of local found_roots {
+        local gname "`prefix'`root'"
+        local path `"```prefix'`root'''"'
+        noi di _n as text "{pstd}Root {it:`root'} was set to {result:`path'} using global {result:{c S|}{c -(}`gname'{c )-}} {p_end}"
+        global `gname' "`path'"
+      }
+
       noi di _n `"{hline}"'
     }
 
@@ -212,41 +234,55 @@ qui {
 }
 end
 
-
 cap program drop   di_search_results
     program define di_search_results
 
-  syntax, time(numlist) dcount(numlist) [rootdirs(string) total]
+  syntax, time(numlist) dcount(numlist) [rootdirs(string) total verbose]
 
   local time: display %8.2f `time'
   local dcount: display %14.0fc `dcount'
-
-  local rcount: list sizeof rootdirs
-
   local time   = trim("`time'")
   local dcount = trim("`dcount'")
+
+  local rcount: list sizeof rootdirs
 
   if missing("`total'") local intro_str "In this search directory"
   else local intro_str "In total"
 
-  noi di as result _n `"{pstd}`intro_str', `dcount' directories were searched in `time' seconds, and `rcount' reproot   root(s) were found.{p_end}"' _n
+  noi di as result _n `"{pstd}`intro_str', `dcount' directories were searched in `time' seconds, and `rcount' unique reproot root(s) were found.{p_end}"' _n
+
+  if !missing("`verbose'") {
+    noi di as result "{pstd}The following root folders were found:{p_end}"
+    foreach rootdir of local rootdirs {
+      local rootdir_list "`rootdir_list'- {it:`rootdir'}{break}"
+    }
+    noi di as text `"{pmore}`rootdir_list'{p_end}"' _n
+  }
 end
 
 
 cap program drop   validate_global_name
     program define validate_global_name, rclass
 
-    syntax, gname(string)
+    syntax, rootname(string) [prefix(string)]
 
     * Create a test value to be stored
     local test_value = "test-repkit-%-1234"
 
+    * Create the global name that will be used
+    local gname "`prefix'`rootname'"
+    cap local preserve_value `"${`gname'}"'
+
     * Use the global name to test if it can be used to
     * store and retreive the global name
     capture {
+      * Load the test value into the global name
       global `gname' = `"`test_value'"'
-      local stored_test_value = `"${`gname'}"'
-      assert `"`test_value'"' == `"`stored_test_value'"'
+      * Stata does not give error on global names such as "te&st",
+      * but those names fail when retreiving the global
+      assert `"`test_value'"' == `"${`gname'}"'
+      * Reset global
+      global `gname' = "`preserve_value'"
     }
 
     * Return 1 if the name was legal (i.e. capture returned 0)

--- a/src/ado/reproot.ado
+++ b/src/ado/reproot.ado
@@ -12,23 +12,27 @@ qui {
 
     noi di _n "{hline}"
 
-    * initiate locals
-    local tot_time 0
-    local tot_dirs 0
-    local rootfiles ""
+    /***************************************************
+      Initiate locals
+    ***************************************************/
 
+    * Hardcoded file names
     local env_file  "~/reproot-env.yaml"
     local root_file "reproot.yaml"
+
+    * Counters
+    local tot_time 0
+    local tot_dirs 0
+
+    * Data locals
+    local rootfiles    ""
+    local all_roots    : list roots | optroots
+    local roots_set    ""
+    local roots_notset ""
 
     /***************************************************
       Test if all roots are already loaded
     ***************************************************/
-
-    * List of all roots - required or optional
-    local all_roots : list roots | optroots
-
-    local roots_set ""
-    local roots_notset ""
 
     * If clear is used, then add all roots to roots_notset,
     * and search for all of them again

--- a/src/ado/reproot.ado
+++ b/src/ado/reproot.ado
@@ -119,7 +119,7 @@ qui {
       * Test if this location has a root file
       cap confirm file "`env_file'"
       if (_rc) {
-        noi di as text `"{phang}No file {inp:reproot-env.yaml} found in home directory {it:`homedir'}. This file is required to set up once per computer to use {cmd:reproot}. See instructions on how to set up this file {browse "https://worldbank.github.io/repkit/articles/reproot-files.html":here}.{p_end}"' _n
+        noi di as error `"{phang}No file {inp:reproot-env.yaml} found in home directory {it:`homedir'}. This file is required to set up once per computer to use {cmd:reproot}. See instructions on how to set up this file {browse "https://worldbank.github.io/repkit/articles/reproot-files.html":here} or use command {browse "https://worldbank.github.io/repkit/reference/reproot_setup.html":reproot_setup}.{p_end}"' _n
         error 601
         exit
       }
@@ -128,6 +128,13 @@ qui {
       reproot_parse env , file("`env_file'")
       local envpaths `"`r(envpaths)'"'
       local skipdirs `"`r(skipdirs)'"'
+
+      * Test that the environment file has at least one search path
+      if missing(`"`envpaths'"') {
+        noi di as error `"{phang}The file {inp:reproot-env.yaml} found in home directory {it:`homedir'} as no paths and will therefore not find any roots. See instructions on how to set up this file {browse "https://worldbank.github.io/repkit/articles/reproot-files.html":here}.{p_end}"' _n
+        error 99
+        exit
+      }
 
       /***************************************************
         Search each reprootpaths

--- a/src/ado/reproot_parse.ado
+++ b/src/ado/reproot_parse.ado
@@ -11,12 +11,12 @@ qui {
     syntax anything, file(string)
 
     if ("`anything'" == "env")       {
-      reproot_parse_env , file("`file'")
+      noi reproot_parse_env , file("`file'")
       return local envpaths = `"`r(envpaths)'"'
       return local skipdirs = `"`r(skipdirs)'"'
     }
     else if ("`anything'" == "root") {
-      reproot_parse_root, file("`file'")
+      noi reproot_parse_root, file("`file'")
       return local project = `"`r(project)'"'
       return local root    = `"`r(root)'"'
     }
@@ -30,7 +30,7 @@ end
 
 cap program drop   reproot_parse_env
     program define reproot_parse_env, rclass
-
+qui {
     syntax, file(string)
 
     local paths    ""
@@ -144,11 +144,13 @@ cap program drop   reproot_parse_env
 
     return local envpaths = trim(`"`formatted_paths'"')
     return local skipdirs `"`skipdirs'"'
+}
 end
 
 cap program drop   reproot_parse_root
     program define reproot_parse_root, rclass
 
+qui {
     * Update the syntax. This is only a placeholder to make the command run
     syntax, file(string)
 
@@ -224,7 +226,7 @@ cap program drop   reproot_parse_root
     * Return rpoject and root
     return local project = trim("`project_name'")
     return local root    = trim("`root_name'")
-
+}
 end
 
 

--- a/src/ado/reproot_search.ado
+++ b/src/ado/reproot_search.ado
@@ -39,9 +39,8 @@ qui {
 
     * Test if this location has a root file
     cap confirm file "`path'/`root_file'"
-    * File found, handle it
+    * File found, add it to rootdirs
     if (_rc == 0) {
-      noi di as text "{phang}{bf:root:} {it:`path'}{p_end}"
       local rootdirs `""`path'""'
     }
 
@@ -66,7 +65,7 @@ qui {
       * Recure into dirs unless it is part of skip folders
       foreach dir of local dir_list {
         if !(`: list dir in skipdirs') {
-          reproot_search,             ///
+          noi reproot_search,             ///
             path("`path'/`dir'")      ///
             recsleft(`next_recsleft') ///
             skipdirs(`skipdirs')      ///

--- a/src/ado/reproot_setup.ado
+++ b/src/ado/reproot_setup.ado
@@ -8,9 +8,161 @@ qui {
     version /* ADD VERSION NUMBER HERE */
 
     * Update the syntax. This is only a placeholder to make the command run
-    syntax [anything]
+    syntax, [ENVPaths(string)]
 
-    //TODO : implement command here
-    
+    * Test that envpath exists
+    foreach envpath in `"`envpaths'"' {
+      test_envpath, envpath(`"`envpath'"') error
+    }
+
+    * Hardcoded file names
+    local env_file  "~/reproot-env-test.yaml"
+
+    * Test if env file already exists
+    cap confirm file "`env_file'"
+    if (_rc)  local env_file_exists 0
+    else      local env_file_exists 1
+
+    if (`env_file_exists') {
+        noi di as result _n `"{pstd}An environment file was found in the home folder [`home_fld']. To modify this file, see {browse "https://worldbank.github.io/repkit/articles/reproot-files.html":this guide}.{p_end}"'
+    }
+    else {
+      noi reproot_setup_envfile, env_file("`env_file'") envpaths(`" "`envpaths'" "')
+    }
+}
+end
+
+cap program drop   reproot_setup_envfile
+    program define reproot_setup_envfile
+
+qui {
+
+    syntax, env_file(string) [envpaths(string)]
+
+    * Get home folder using cd and then restore the orginal cd
+    local preserve_pwd "`c(pwd)'"
+    cd ~
+    local home_fld "`c(pwd)'"
+    cd "`preserve_pwd'"
+
+    * Ask for confirmation
+    noi di as result _n `"{pstd}No environment file was found in the home folder [`home_fld']. This command can set up a template. In the workflow of {inp:reproot}, this file must be located in the home folder.{p_end}"' _n(2) `"{pstd}Do you want to set up a template in the home folder?{p_end}"'
+    global setup_confirmation ""
+    while (!inlist(upper("${setup_confirmation}"),"Y", "N")) {
+      noi di as txt `"{pstd}Enter "Y" to set up an environment template file or enter "N" to abort."', _request(setup_confirmation)
+    }
+    if upper("${setup_confirmation}") == "N" {
+      noi di as txt "{pstd}Environment file creation aborted - nothing was created.{p_end}"
+      error 1
+      exit
+    }
+
+    noi di as result _n `"{pstd}The environment file will only work if it has at least one environment search paths. Read more about the environment file and its settings in the {browse "https://worldbank.github.io/repkit/articles/reproot-files.html":this guide}.{p_end}"' _n(2) `"{pstd}Do you want to add search folders? It is possible to do this later see the guide (also linked to in the help file for this command) for how to modify this file later.{p_end}"'
+
+    global path_to_add ""
+    while (!inlist(upper("${path_to_add}"),"BREAK","DONE")) {
+      noi display_envpath, envpaths(`"`envpaths'"')
+      noi di as txt `"{pstd}Enter a single folder path or enter "DONE" to create the file with these files, or "BREAK" to abort."', _request(path_to_add)
+
+      * Do not test of add keywords
+      if (!inlist(upper("${path_to_add}"),"BREAK","DONE")) {
+        test_envpath, envpath(${path_to_add})
+        if (`r(path_exists)' == 0)  noi di as txt "{pstd}{red:Warning}:This path does not exist.{p_end}"
+        else local envpaths `"`envpaths' "${path_to_add}" "'
+      }
+    }
+
+    * Abort if break was the key word
+    if upper("${path_to_add}") == "BREAK" {
+      noi di as txt "{pstd}Environment file creation aborted - nothing was created.{p_end}"
+      error 1
+      exit
+    }
+
+    noi create_env_file, env_file("`env_file'") envpaths(`"`envpaths'"')
+}
+end
+
+
+* DISPLAY ENVPATH
+cap program drop   create_env_file
+    program define create_env_file, rclass
+qui {
+    syntax, env_file(string) [envpaths(string)]
+
+    * Initiate the tempfile handlers and tempfiles needed
+    tempname env_handle
+    tempfile env_tmpfile
+
+    * Open template to read from and new tempfile to write to
+    file open `env_handle' using `env_tmpfile' , write
+
+    * Write the smcl tag at top of file to
+    file write `env_handle' "recursedepth: 4" _n "paths:" _n
+    foreach envpath of local envpaths {
+      file write `env_handle' `"    - `envpath'"' _n
+    }
+    file write `env_handle' "skipdirs:" _n `"    - ".git""'
+
+    file close `env_handle'
+
+    copy `env_tmpfile' `"`env_file'"'
+
+    noi di as result _n "{pstd}Environment file was succsfully written to home folder.{p_end}"
+}
+end
+
+* TEST ENVPATH
+cap program drop   test_envpath
+    program define test_envpath, rclass
+qui {
+    syntax, envpath(string) [error]
+
+    * Parst the envpath that can either be
+    *  - "4:C:\Users\user1234\github"
+    *  - "C:\Users\user1234\github"
+    gettoken depth path : envpath, parse(":")
+
+    * Test if envpath has depth prepended
+    cap confirm integer number `depth'
+    * no depth prepended, use envpath as is
+    if _rc local path = `"`envpath'"'
+    * depth prepended, use path after removing parse char
+    else   local path = substr("`path'",2,.)
+
+    *Test that path exist
+    mata : st_numscalar("r(dirExist)", direxists(`"`path'"'))
+    local path_exists `r(dirExist)'
+    return local path_exists `path_exists'
+
+    * If the path exists, return it
+    if (`path_exists' == 1) {
+      return local existing_path `path'
+    }
+    * if path does not exists, and error is used, throw error
+    else {
+      if !missing("`error'") {
+        noi di as error `"{phang}The folder in "`path'" does not exists, you may only use folders that already exists.{p_end}"'
+        error 693
+        exit
+      }
+    }
+}
+end
+
+
+* DISPLAY ENVPATH
+cap program drop   display_envpath
+    program define display_envpath, rclass
+qui {
+    syntax, [envpaths(string)]
+    if !missing("`envpaths'") {
+      local di_paths ""
+      * Test that envpath exists
+      foreach envpath of local envpaths {
+        local di_paths "`di_paths'{break}- `envpath'"
+      }
+      noi di as result _n `"{pstd}This is the list of paths that will be added:`di_paths'{p_end}"' _n
+    }
 }
 end

--- a/src/ado/reproot_setup.ado
+++ b/src/ado/reproot_setup.ado
@@ -1,0 +1,16 @@
+*! version XX XXXXXXXXX ADAUTHORNAME ADCONTACTINFO
+
+cap program drop   reproot_setup
+    program define reproot_setup
+
+qui {
+
+    version /* ADD VERSION NUMBER HERE */
+
+    * Update the syntax. This is only a placeholder to make the command run
+    syntax [anything]
+
+    //TODO : implement command here
+    
+}
+end

--- a/src/ado/reproot_setup.ado
+++ b/src/ado/reproot_setup.ado
@@ -8,7 +8,17 @@ qui {
     version /* ADD VERSION NUMBER HERE */
 
     * Update the syntax. This is only a placeholder to make the command run
-    syntax, [ENVPaths(string)]
+    syntax, [ENVPaths(string) debug_home_folder(string)]
+
+
+    * Get home folder using cd and then restore the orginal cd
+    local preserve_pwd "`c(pwd)'"
+    cd ~
+    local home_fld "`c(pwd)'"
+    cd "`preserve_pwd'"
+
+    * This is used for testing purpose during development only
+    if !missing("`debug_home_folder'") local home_fld  "`debug_home_folder'"
 
     * Test that envpath exists
     foreach envpath in `"`envpaths'"' {
@@ -16,7 +26,8 @@ qui {
     }
 
     * Hardcoded file names
-    local env_file  "~/reproot-env-test.yaml"
+    local env_file  "`home_fld'/reproot-env.yaml"
+
 
     * Test if env file already exists
     cap confirm file "`env_file'"
@@ -27,7 +38,7 @@ qui {
         noi di as result _n `"{pstd}An environment file was found in the home folder [`home_fld']. To modify this file, see {browse "https://worldbank.github.io/repkit/articles/reproot-files.html":this guide}.{p_end}"'
     }
     else {
-      noi reproot_setup_envfile, env_file("`env_file'") envpaths(`" "`envpaths'" "')
+      noi reproot_setup_envfile, env_file("`env_file'") envpaths(`"`envpaths'"') home_fld("`home_fld'")
     }
 }
 end
@@ -37,13 +48,7 @@ cap program drop   reproot_setup_envfile
 
 qui {
 
-    syntax, env_file(string) [envpaths(string)]
-
-    * Get home folder using cd and then restore the orginal cd
-    local preserve_pwd "`c(pwd)'"
-    cd ~
-    local home_fld "`c(pwd)'"
-    cd "`preserve_pwd'"
+    syntax, env_file(string) home_fld(string) [envpaths(string)]
 
     * Ask for confirmation
     noi di as result _n `"{pstd}No environment file was found in the home folder [`home_fld']. This command can set up a template. In the workflow of {inp:reproot}, this file must be located in the home folder.{p_end}"' _n(2) `"{pstd}Do you want to set up a template in the home folder?{p_end}"'
@@ -62,7 +67,7 @@ qui {
     global path_to_add ""
     while (!inlist(upper("${path_to_add}"),"BREAK","DONE")) {
       noi display_envpath, envpaths(`"`envpaths'"')
-      noi di as txt `"{pstd}Enter a single folder path or enter "DONE" to create the file with these files, or "BREAK" to abort."', _request(path_to_add)
+      noi di as txt `"{pstd}Enter single folder path or enter "DONE" to create the file with these files, or "BREAK" to abort."', _request(path_to_add)
 
       * Do not test of add keywords
       if (!inlist(upper("${path_to_add}"),"BREAK","DONE")) {
@@ -116,35 +121,37 @@ end
 cap program drop   test_envpath
     program define test_envpath, rclass
 qui {
-    syntax, envpath(string) [error]
+    syntax, [envpath(string) error]
 
-    * Parst the envpath that can either be
-    *  - "4:C:\Users\user1234\github"
-    *  - "C:\Users\user1234\github"
-    gettoken depth path : envpath, parse(":")
+    if !missing("`envpath'") {
+      * Parst the envpath that can either be
+      *  - "4:C:\Users\user1234\github"
+      *  - "C:\Users\user1234\github"
+      gettoken depth path : envpath, parse(":")
 
-    * Test if envpath has depth prepended
-    cap confirm integer number `depth'
-    * no depth prepended, use envpath as is
-    if _rc local path = `"`envpath'"'
-    * depth prepended, use path after removing parse char
-    else   local path = substr("`path'",2,.)
+      * Test if envpath has depth prepended
+      cap confirm integer number `depth'
+      * no depth prepended, use envpath as is
+      if _rc local path = `"`envpath'"'
+      * depth prepended, use path after removing parse char
+      else   local path = substr("`path'",2,.)
 
-    *Test that path exist
-    mata : st_numscalar("r(dirExist)", direxists(`"`path'"'))
-    local path_exists `r(dirExist)'
-    return local path_exists `path_exists'
+      *Test that path exist
+      mata : st_numscalar("r(dirExist)", direxists(`"`path'"'))
+      local path_exists `r(dirExist)'
+      return local path_exists `path_exists'
 
-    * If the path exists, return it
-    if (`path_exists' == 1) {
-      return local existing_path `path'
-    }
-    * if path does not exists, and error is used, throw error
-    else {
-      if !missing("`error'") {
-        noi di as error `"{phang}The folder in "`path'" does not exists, you may only use folders that already exists.{p_end}"'
-        error 693
-        exit
+      * If the path exists, return it
+      if (`path_exists' == 1) {
+        return local existing_path `path'
+      }
+      * if path does not exists, and error is used, throw error
+      else {
+        if !missing("`error'") {
+          noi di as error `"{phang}The folder in "`path'" does not exists, you may only use folders that already exists.{p_end}"'
+          error 693
+          exit
+        }
       }
     }
 }
@@ -156,7 +163,7 @@ cap program drop   display_envpath
     program define display_envpath, rclass
 qui {
     syntax, [envpaths(string)]
-    if !missing("`envpaths'") {
+    if !missing(`"`envpaths'"') {
       local di_paths ""
       * Test that envpath exists
       foreach envpath of local envpaths {

--- a/src/mdhlp/reproot.md
+++ b/src/mdhlp/reproot.md
@@ -4,14 +4,16 @@ __reproot__ - Command for managing root file paths.
 
 # Syntax
 
-__reproot__ , __**p**roject__(_string_) __**r**oots__(_string_) [ __**pre**fix__(_string_) __clear__]
+__reproot__ , __**p**roject__(_string_) __**r**oots__(_string_) [ __**optr**oots__(_string_) __**pre**fix__(_string_) __clear__ __verbose__]
 
 | _options_ | Description |
 |-------------|-----------------|
-| __**p**roject__(_string_) | The project name to search roots for. |
-| __**r**oots__(_string_) | The root name(s) to search for. |
-| __**pre**fix__(_string_) | Adds a project-specific prefix to root globals. |
-| __clear__ | Always search for roots even if already loaded. |
+| __**p**roject__(_string_) | The project name to search roots for |
+| __**r**oots__(_string_) | Required root name(s) to search for |
+| __**optr**oots__(_string_) | Optional root name(s) to also search for |
+| __**pre**fix__(_string_) | Adds a project-specific prefix to root globals |
+| __clear__ | Always search for roots even if already loaded |
+| __verbose__ | More verbose output about roots found |
 
 `reproot` is a framework for automatically handling file paths across
 teams without requiring project-specific setup from individual users.
@@ -50,12 +52,18 @@ __roots__(_string_) indicates which roots are expected to be found for this proj
 The command creates a global based on the root name of that root
 if that root folder is found.
 The content of the global will be the file path to the location of the root file.
-This command does not set globals for roots not listed here,
+This command does not set globals for roots not listed in this option
+(or in `optroots()` - see below),
 even if such roots for this project were found.
 Unless the __clear__ option is used,
-the command does not overwrite any global that already existed before running the command.
+the command does not overwrite any global that
+already had content before running the command.
 Finally, the command tests that there is a global named after each root and
 that all of them are non-empty.
+
+__optroots__(_string_) allows the users to set optional roots.
+They will be treated the same way as the roots in `roots()` with
+the one exception that no error is thrown if this root is not found.
 
 __prefix__(_string_) allows the user to set a project-specific global prefix.
 This is strongly recommended to ensure that a global from another project
@@ -72,6 +80,9 @@ This is all the roots listed in __roots()__ with
 the __prefix()__ prepended if that option is used.
 The default behavior is to not search for roots that are already set up.
 If all globals are already set, then the command does not execute the search for roots.
+
+__verbose__ makes the command output more information about what roots were found.
+This option is helpful for debugging when trying to figure out what roots are found and not found.
 
 # Examples
 

--- a/src/mdhlp/reproot.md
+++ b/src/mdhlp/reproot.md
@@ -67,7 +67,7 @@ The __prefix()__ option allows a project-specific prefix that is set to all glob
 So, if __prefix("abc_")__ is used, then the globals `data` and `code`
 will be set to `abc_data` and `abc_code`.
 
-__clear__ overwrites globals that already exist with the name that `reproot` would creaet.
+__clear__ overwrites globals that already exist with the name that `reproot` would create.
 This is all the roots listed in __roots()__ with
 the __prefix()__ prepended if that option is used.
 The default behavior is to not search for roots that are already set up.

--- a/src/mdhlp/reproot_setup.md
+++ b/src/mdhlp/reproot_setup.md
@@ -1,0 +1,31 @@
+# Title
+
+__reproot_setup__ - This command is used for short description.
+
+# Syntax
+
+__reproot_setup__ , __**opt**ion1__(_string_)
+
+| _options_ | Description |
+|-----------|-------------|
+| __**opt**ion1__(_string_) | Short description of option1 |
+
+# Description
+<!-- Longer description of the intended use of the command and best practices related to the usage -->
+
+# Options
+<!-- Longer description (paragraph length) of all options, their intended use case and best practices related to them -->
+
+__**opt**ion1__(_string_) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
+
+# Stored results
+<!-- Document all results this command returns as either r-class, e-class or s-class macros -->
+
+# Examples
+<!-- A couple of examples to help the user get started and a short explanation of each of them -->
+
+# Feedback, bug reports and contributions
+<!-- Guidelines for how to provide feedback, bug reports or contributions for this package. Include an email or links to GitHub repo -->
+
+# Authors
+<!-- A couple of examples to help the user get started and a short explanation of each of them -->

--- a/src/mdhlp/reproot_setup.md
+++ b/src/mdhlp/reproot_setup.md
@@ -4,28 +4,29 @@ __reproot_setup__ - This command is used for short description.
 
 # Syntax
 
-__reproot_setup__ , __**opt**ion1__(_string_)
+__reproot_setup__ , __**envp**aths__(_string_)
 
 | _options_ | Description |
 |-----------|-------------|
-| __**opt**ion1__(_string_) | Short description of option1 |
+| __**envp**aths__(_string_) | Root paths to be added to the environment file |
 
 # Description
-<!-- Longer description of the intended use of the command and best practices related to the usage -->
+
+This command helps setting up the environment file used in the command
+[reproot](https://worldbank.github.io/repkit/reference/reproot.html).
+Read more about the environment file
+[here](https://worldbank.github.io/repkit/articles/reproot-files.html).
 
 # Options
-<!-- Longer description (paragraph length) of all options, their intended use case and best practices related to them -->
 
-__**opt**ion1__(_string_) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
-
-# Stored results
-<!-- Document all results this command returns as either r-class, e-class or s-class macros -->
-
-# Examples
-<!-- A couple of examples to help the user get started and a short explanation of each of them -->
+__**envp**aths__(_string_) is used for list files to be added to the environment file.
+Paths can also be added interactively when running the command.
 
 # Feedback, bug reports and contributions
-<!-- Guidelines for how to provide feedback, bug reports or contributions for this package. Include an email or links to GitHub repo -->
+
+Read more about these commands on [this repo](https://github.com/worldbank/repkit) where this package is developed. Please provide any feedback by [opening an issue](https://github.com/worldbank/repkit/issues). PRs with suggestions for improvements are also greatly appreciated.
 
 # Authors
-<!-- A couple of examples to help the user get started and a short explanation of each of them -->
+
+LSMS Team, The World Bank lsms@worldbank.org
+DIME Analytics, The World Bank dimeanalytics@worldbank.org

--- a/src/repkit.pkg
+++ b/src/repkit.pkg
@@ -24,6 +24,7 @@ d
 d Distribution-Date: 20240516
 d
 *** adofiles
+f ado/reproot_setup.ado
 f ado/repadolog.ado
 f ado/reproot_search.ado
 f ado/reproot_parse.ado
@@ -34,6 +35,7 @@ f ado/repado.ado
 f ado/repkit.ado
 
 *** helpfiles
+f sthlp/reproot_setup.sthlp
 f sthlp/repadolog.sthlp
 f sthlp/reproot.sthlp
 f sthlp/reprun.sthlp

--- a/src/sthlp/reproot_setup.sthlp
+++ b/src/sthlp/reproot_setup.sthlp
@@ -11,26 +11,36 @@
 
 {title:Syntax}
 
-{phang}{bf:reproot_setup} , {bf:{ul:opt}ion1}({it:string})
+{phang}{bf:reproot_setup} , {bf:{ul:envp}aths}({it:string})
 {p_end}
 
-{synoptset 15}{...}
+{synoptset 16}{...}
 {p2coldent:{it:options}}Description{p_end}
 {synoptline}
-{synopt: {bf:{ul:opt}ion1}({it:string})}Short description of option1{p_end}
+{synopt: {bf:{ul:envp}aths}({it:string})}Root paths to be added to the environment file{p_end}
 {synoptline}
 
 {title:Description}
 
-{title:Options}
-
-{pstd}{bf:{ul:opt}ion1}({it:string}) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
+{pstd}This command helps setting up the environment file used in the command
+{browse "https://worldbank.github.io/repkit/reference/reproot.html":reproot}.
+Read more about the environment file
+{browse "https://worldbank.github.io/repkit/articles/reproot-files.html":here}.
 {p_end}
 
-{title:Stored results}
+{title:Options}
 
-{title:Examples}
+{pstd}{bf:{ul:envp}aths}({it:string}) is used for list files to be added to the environment file.
+Paths can also be added interactively when running the command.
+{p_end}
 
 {title:Feedback, bug reports and contributions}
 
+{pstd}Read more about these commands on {browse "https://github.com/worldbank/repkit":this repo} where this package is developed. Please provide any feedback by {browse "https://github.com/worldbank/repkit/issues":opening an issue}. PRs with suggestions for improvements are also greatly appreciated.
+{p_end}
+
 {title:Authors}
+
+{pstd}LSMS Team, The World Bank lsms@worldbank.org
+DIME Analytics, The World Bank dimeanalytics@worldbank.org
+{p_end}

--- a/src/sthlp/reproot_setup.sthlp
+++ b/src/sthlp/reproot_setup.sthlp
@@ -1,0 +1,36 @@
+{smcl}
+{* *! version 2.1 20240516}{...}
+{hline}
+{pstd}help file for {hi:reproot_setup}{p_end}
+{hline}
+
+{title:Title}
+
+{phang}{bf:reproot_setup} - This command is used for short description.
+{p_end}
+
+{title:Syntax}
+
+{phang}{bf:reproot_setup} , {bf:{ul:opt}ion1}({it:string})
+{p_end}
+
+{synoptset 15}{...}
+{p2coldent:{it:options}}Description{p_end}
+{synoptline}
+{synopt: {bf:{ul:opt}ion1}({it:string})}Short description of option1{p_end}
+{synoptline}
+
+{title:Description}
+
+{title:Options}
+
+{pstd}{bf:{ul:opt}ion1}({it:string}) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
+{p_end}
+
+{title:Stored results}
+
+{title:Examples}
+
+{title:Feedback, bug reports and contributions}
+
+{title:Authors}

--- a/src/tests/reproot_setup/reproot_setup.do
+++ b/src/tests/reproot_setup/reproot_setup.do
@@ -33,6 +33,8 @@
     * Run tests
 
     * Test basic case of the command reproot_setup
-    reproot_setup, envpath("C:\Users\WB462869\Dropbox\DIME Analytics")
+    local test_homefolder "`testfldr'/reproot_setup"
+    cap rm "`test_homefolder'/reproot-env.yaml"
+    reproot_setup, envpath(`"${repkit_clone}"') debug_home_folder("`test_homefolder'")
 
     // Add more tests here...

--- a/src/tests/reproot_setup/reproot_setup.do
+++ b/src/tests/reproot_setup/reproot_setup.do
@@ -31,10 +31,14 @@
 
     ************************
     * Run tests
+    local test_homefolder "`testfldr'/reproot_setup"
 
     * Test basic case of the command reproot_setup
-    local test_homefolder "`testfldr'/reproot_setup"
     cap rm "`test_homefolder'/reproot-env.yaml"
     reproot_setup, envpath(`"${repkit_clone}"') debug_home_folder("`test_homefolder'")
+    
+    * Test basic case of the command reproot_setup
+    cap rm "`test_homefolder'/reproot-env.yaml"
+    reproot_setup, debug_home_folder("`test_homefolder'")
 
     // Add more tests here...

--- a/src/tests/reproot_setup/reproot_setup.do
+++ b/src/tests/reproot_setup/reproot_setup.do
@@ -15,7 +15,7 @@
     reproot, project("repkit") roots("clone") prefix("repkit_")
 
     * Use locals for all non-root paths
-    local testfldr "${adwn_clone}/src/tests"
+    local testfldr "${repkit_clone}/src/tests"
 
     * Use the /dev-env folder as a dev environment
     cap mkdir    "`testfldr'/dev-env"
@@ -33,6 +33,6 @@
     * Run tests
 
     * Test basic case of the command reproot_setup
-    reproot_setup
+    reproot_setup, envpath("C:\Users\WB462869\Dropbox\DIME Analytics")
 
     // Add more tests here...

--- a/src/tests/reproot_setup/reproot_setup.do
+++ b/src/tests/reproot_setup/reproot_setup.do
@@ -1,0 +1,38 @@
+    * This test file use utilities from the repkit package - https://github.com/worldbank/repkit
+    * Test if package is installed, otherwise throw error telling user to install repkit
+    cap which repkit
+    if _rc == 111 {
+        di as error "{pstd}You need to have {cmd:repkit} installed to run this reproducibility package. Click {stata ssc install repkit, replace} to do so.{p_end}"
+    }
+
+    ************************
+    * Set up root paths (if not already set), and set up dev environment
+
+    * Always important to version control built-in Stata functions
+    version 14.1
+
+    * Use reproot to manage root path
+    reproot, project("repkit") roots("clone") prefix("repkit_")
+
+    * Use locals for all non-root paths
+    local testfldr "${adwn_clone}/src/tests"
+
+    * Use the /dev-env folder as a dev environment
+    cap mkdir    "`testfldr'/dev-env"
+    repado using "`testfldr'/dev-env"
+
+    * Make sure repkit is installed also in the dev environment
+    cap which repkit
+    if _rc == 111 ssc install repkit
+
+    * Make sure the version of repkit in the dev environment us up to date with all edits.
+    cap net uninstall repkit
+    net install repkit, from("${repkit_clone}/src") replace
+
+    ************************
+    * Run tests
+
+    * Test basic case of the command reproot_setup
+    reproot_setup
+
+    // Add more tests here...

--- a/src/vignettes/reproot-files.md
+++ b/src/vignettes/reproot-files.md
@@ -47,7 +47,7 @@ If these files are shared over DropBox/OneDrive/Git/Network, etc. among the othe
 
 A template root file can be downloaded from [here](https://github.com/worldbank/repkit/blob/main/src/dev/reproot.yaml) for you to download it and modify it to your needs.
 
-### `reproot-env.yaml` - the settings file
+### `reproot-env.yaml` - the environment settings file
 
 Searching all folders on a computer file system would make `reproot` prohibitively slow. However, with some simple settings, the number of folders that need to be searched can be drastically reduced. These settings are done in the `reproot-env.yaml` file.
 
@@ -68,7 +68,7 @@ A lower recurse depth will be faster, but it might prevent `reproot` from findin
 
 It is typically better to add more search paths rather than increasing the recurse depth a lot. However, the best trade-off between the number of search paths and depends on how you have organized the files on your computer. You should experiment until you've found a combination of search paths and recurse depth that both find all the root files and do so within a reasonable time.
 
-#### `paths`
+#### Search `paths`
 
 * Required: Yes
 * Format: A list of strings that are absolute file paths


### PR DESCRIPTION
This PR fixes:

* #27 - throw error if not all required roots are found
* #28 - test that global name is valid
* #30 - typo in docs
* #34 - allow optional roots that do not trigger errors if not found
* #58 - create `reproot_setup`. A very basic utility tool to create the `reproot-env.yaml` file. 

