### PR TITLE
Fixes a few characters in strings

### DIFF
--- a/src/ado/reprun.ado
+++ b/src/ado/reprun.ado
@@ -166,7 +166,7 @@ end
   program define   reprun_recurse, rclass
   qui {
 
-    syntax, dofile(string) output(string) stub(string)
+    syntax, dofile(string asis) output(string) stub(string)
 
     /*************************************************************************
       Create the files that this recursive call needs
@@ -205,7 +205,8 @@ end
 
     * Open the orginal file
     tempname   code_orig
-    file open `code_orig' using "`dofile'", read
+
+    file open `code_orig' using `dofile', read
 
     * Loop until end of file
     while `leof' == 0 {
@@ -358,8 +359,11 @@ end
             * Test if it should recurse or not
             if `recurse' == 1 {
 
+
               * Keep working on the stub
               local recursestub "`stub'_`++subf_n'"
+
+
 
               noi reprun_recurse, dofile(`file')     ///
                     output("`output'")   ///
@@ -369,10 +373,12 @@ end
 
 
               * Substitute the original sub-dofile with the check/write ones
+              if !strpos(`"`file'"',`"""') local file `""`file'""'
+
               local run1_line = ///
-                subinstr(`"`line'"',`"`file'"',`""`sub_f1'""',1)
+                subinstr(`"`line'"',`file',`""`sub_f1'""',1)
               local run2_line = ///
-                subinstr(`"`line'"',`"`file'"',`""`sub_f2'""',1)
+                subinstr(`"`line'"',`file',`""`sub_f2'""',1)
 
               *Correct potential ""path"" to "path"
               local run1_line = subinstr(`"`run1_line'"',`""""',`"""',.)

--- a/src/ado/reprun.ado
+++ b/src/ado/reprun.ado
@@ -275,8 +275,17 @@ end
           while regexm(`"`macval(theline)'"',"[\*]") {
             local theline = regexr(`"`macval(theline)'"',"[\*]","")
           }
-          while regexm(`"`macval(theline)'"',"\[//]"){
+          while regexm(`"`macval(theline)'"',"\[//]") {
             local theline = regexr(`"`macval(theline)'"',"\[//]","")
+          }
+		  while regexm(`"`macval(theline)'"',"[\[]|[\]]") {
+            local theline = regexr(`"`macval(theline)'"',"[\[]|[\]]","")
+          }
+		  while regexm(`"`macval(theline)'"',"[\(]|[\)]") {
+            local theline = regexr(`"`macval(theline)'"',"[\(]|[\)]","")
+          }
+		  while regexm(`"`macval(theline)'"', char(34)) {
+            local theline = regexr(`"`macval(theline)'"', char(34), "")
           }
 
           // Identify all commands in line

--- a/src/ado/reprun_dataline.ado
+++ b/src/ado/reprun_dataline.ado
@@ -14,7 +14,7 @@ cap program drop   reprun_dataline
       [ ///
       datatmp(string)     /// The tempfile that holds the RNG etc. data
       recursestub(string) /// keep track of sub-do-file
-      orgsubfile(string)  ///
+      orgsubfile(string asis)  ///
       looptracker(string) /// keeps track of inside a loop
       ]
 
@@ -49,7 +49,7 @@ cap program drop   reprun_dataline
     * Recurse line
     else {
       *Build recurse instructions line
-      local line `"recurse `recursestub' "`orgsubfile'" "'
+      local line `"recurse `recursestub' `orgsubfile' "'
     }
 
     *Write line and close file

--- a/src/tests/reprun/reprun.do
+++ b/src/tests/reprun/reprun.do
@@ -36,6 +36,10 @@
     cap mkdir "${tf}/output-1"
     cap mkdir "${tf}/output-2"
     cap mkdir "${tf}/output-3"
+
+    reprun "${tf}/comments.do" using "${tf}/comments" , debug
+    // reprun "${tf}/recursion.do" using "${tf}/recursion" , debug
+
     reprun "${tf}/target-1.do" using "${tf}/output-1" , debug
     reprun "${tf}/target-1.do" using "${tf}/output-1" , v debug
     reprun "${tf}/target-1.do" using "${tf}/output-1" , c debug

--- a/src/tests/reprun/targets/comments.do
+++ b/src/tests/reprun/targets/comments.do
@@ -1,0 +1,14 @@
+
+* Bad comment
+* Worse comment "
+/* a comment "
+  from the "
+  bad place */
+/* Weird comment */
+// TEST COMMENT
+
+// TEST COMMENT [
+// TEST COMMENT (
+// TEST COMMENT *
+
+// EOF 

--- a/src/tests/reprun/targets/recursion.do
+++ b/src/tests/reprun/targets/recursion.do
@@ -1,0 +1,16 @@
+
+do "target-2.do" // missing do-file do "${tf}/target-dontrun.do"
+
+* do "${tf}/target-dontrun.do"
+
+// do "${tf}/target-dontrun.do"
+
+// do "${tf}/target-dontrun.do"
+
+/* a comment "
+  from the "
+  do bad place */
+
+/*
+do "${tf}/target-dontrun.do"
+*/

--- a/src/tests/reprun/targets/target-1.do
+++ b/src/tests/reprun/targets/target-1.do
@@ -31,9 +31,6 @@ local check : var lab price`domain_num'
 su  /// error 196
   price
 
-* Bad comment
-/* Weird comment */
-// TEST COMMENT
 
 global something "nothing"
 
@@ -57,17 +54,7 @@ gen y = rnormal()
 
 cap duplicates drop make , force
 
-do "target-2.do" // missing do-file do "${tf}/target-dontrun.do"
 
-* do "${tf}/target-dontrun.do"
-
-// do "${tf}/target-dontrun.do"
-
-// do "${tf}/target-dontrun.do"
-
-/*
-do "${tf}/target-dontrun.do"
-*/
 
 if (1 == 1) & (1 == 1) do "${tf}/target-2.do"
 


### PR DESCRIPTION
After testing, found out that the characters `(`, `)`, `[`, and `]` cause the error "{ required" when included in commented-out code.

Also, proposed a solution to `"` and I think it fixes most of the cases. I tested the following and it works:

```
/*******************************************************************************
Name of  file: main.do
testing first instance of "quote
*******************************************************************************/

/* the do-file tests the "second instance of quote
error " */

// test brackets [ 
	sysuse auto, clear
	

* testing open paranthesis (
	bys mpg:  /// sorting by mpg	
	gen dup = cond(_N==1,0,_n)
	
// testing third instance of quote "here	
	drop if dup > 1
```	


But it does **not** work if quote is on the next line of the comment without any space:
```
/* the do-file tests the "second instance of quote
error" */

// test brackets [ 
	sysuse auto, clear
```

It causes the error "too few quotes"
