### PR TITLE
Release v3.1 - minor release - fix rendering of lint help file

### DIFF
--- a/src/ado/lint.ado
+++ b/src/ado/lint.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 capture program drop lint
 		program 	 lint

--- a/src/ado/repado.ado
+++ b/src/ado/repado.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 cap program drop   repado
     program define repado, rclass

--- a/src/ado/repadolog.ado
+++ b/src/ado/repadolog.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 cap program drop   repadolog
     program define repadolog

--- a/src/ado/repkit.ado
+++ b/src/ado/repkit.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 cap program drop   repkit
     program define repkit, rclass
@@ -6,8 +6,8 @@ cap program drop   repkit
     version 14.1
 
     * UPDATE THESE LOCALS FOR EACH NEW VERSION PUBLISHED
-    local version "3.0" 
-    local versionDate "20240923" 
+    local version "3.1" 
+    local versionDate "20240926" 
     local cmd    "repkit"
 
   	syntax [anything]

--- a/src/ado/reproot.ado
+++ b/src/ado/reproot.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 cap program drop   reproot
     program define reproot, rclass

--- a/src/ado/reproot_parse.ado
+++ b/src/ado/reproot_parse.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 cap program drop   reproot_parse
     program define reproot_parse, rclass

--- a/src/ado/reproot_search.ado
+++ b/src/ado/reproot_search.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 cap program drop   reproot_search
     program define reproot_search, rclass

--- a/src/ado/reproot_setup.ado
+++ b/src/ado/reproot_setup.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 cap program drop   reproot_setup
     program define reproot_setup

--- a/src/ado/reprun.ado
+++ b/src/ado/reprun.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 cap program drop   reprun
     program define reprun, rclass

--- a/src/ado/reprun_dataline.ado
+++ b/src/ado/reprun_dataline.ado
@@ -1,4 +1,4 @@
-*! version 3.0 20240923 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
+*! version 3.1 20240926 - DIME Analytics & LSMS Team, The World Bank - dimeanalytics@worldbank.org, lsms@worldbank.org
 
 * Command intended to exclusively be run from the run files
 * that the command iedorep is generating

--- a/src/repkit.pkg
+++ b/src/repkit.pkg
@@ -1,6 +1,6 @@
 * This package file is generated in the adodown workflow. Do not edit directly.
 *** version
-v 3.0
+v 3.1
 *** title
 d 'REPKIT': a module facilitating collaboration and computational reproducibility
 *** description
@@ -21,7 +21,7 @@ d Contact: dimeanalytics@@worldbank.org, lsms@@worldbank.org
 d URL: https://github.com/worldbank/repkit
 d
 *** date
-d Distribution-Date: 20240923
+d Distribution-Date: 20240926
 d
 *** adofiles
 f ado/lint.ado

--- a/src/sthlp/lint.sthlp
+++ b/src/sthlp/lint.sthlp
@@ -6,16 +6,23 @@
 
 {title:Title}
 
-{phang}{bf:lint} -  detects and corrects bad coding practices in Stata do-files following the {browse "https://worldbank.github.io/dime-data-handbook/coding.html#the-dime-analytics-stata-style-guide":DIME Analytics Stata Style Guide}.
+{phang}{bf:lint} - detects and corrects bad coding practices in Stata do-files
+following the
+{browse "https://worldbank.github.io/dime-data-handbook/coding.html#the-dime-
+analytics-stata-style-guide":DIME Analytics Stata Style Guide}.
 {p_end}
 
-{phang}For this command to run, you will need Stata version 16 or greater, Python, and the Python package {browse "https://pandas.pydata.org":Pandas} installed.
+{phang}For this command to run, you will need Stata version 16 or greater,
+Python, and the Python package {browse "https://pandas.pydata.org":Pandas}
+installed.
 {p_end}
 
-{phang}To install Python and integrate it with Stata, refer to {browse "https://blog.stata.com/2020/08/18/stata-python-integration-part-1-setting-up-stata-to-use-python/":this page}.
+{phang}To install Python and integrate it with Stata, refer to
+{browse "https://blog.stata.com/2020/08/18/stata-python-integration-part-1-setting-up-stata-to-use-python/":this page}.
 {p_end}
 
-{phang}To install Python packages, refer to {browse "https://blog.stata.com/2020/09/01/stata-python-integration-part-3-how-to-install-python-packages/":this page}.
+{phang}To install Python packages, refer to
+{browse "https://blog.stata.com/2020/09/01/stata-python-integration-part-3-how-to-install-python-packages/":this page}.
 {p_end}
 
 {title:Syntax}
@@ -32,20 +39,38 @@
 {phang}2. {bf:Correction} corrects bad coding practices in a Stata do-file.
 {p_end}
 
-{phang}If an {it:output_file} is specified with {bf:using}, then the linter will apply the {bf:Correction} functionality and will write a new file with corrections. If not, the command will only apply the {bf:Detection} functionality, returning a report of suggested corrections and potential issues of the do-file in Stata{c 39}s Results window. Users should note that not all the bad practices identified in {bf:Detection} can be amended by {bf:Correction}.
+{phang}If an {it:output_file} is specified with {bf:using}, then the linter will
+apply the {bf:Correction} functionality and will write a new file with
+corrections. If not, the command will only apply the {bf:Detection}
+functionality, returning a report of suggested corrections and potential issues
+of the do-file in Stata{c 39}s Results window. Users should note that not all
+the bad practices identified in {bf:Detection} can be amended by {bf:Correction}.
 {p_end}
 
 {synoptset 16}{...}
 {p2coldent:{it:options}}Description{p_end}
 {synoptline}
-{synopt: {bf:{ul:v}erbose}}Report bad practices and issues found on each line of the do-file.{p_end}
-{synopt: {bf:{ul:nosum}mary}}Suppress summary table of bad practices and potential issues.{p_end}
-{synopt: {bf:{ul:i}ndent}({it:integer})}Number of whitespaces used when checking indentation coding practices (default: 4).{p_end}
-{synopt: {bf:{ul:s}pace}({it:integer})}Number of whitespaces used instead of hard tabs when checking indentation practices (default: same as indent).{p_end}
-{synopt: {bf:{ul:l}inemax}({it:integer})}Maximum number of characters in a line when checking line extension practices (default: 80).{p_end}
-{synopt: {bf:{ul:e}xcel}({it:filename})}Save an Excel file of line-by-line results.{p_end}
-{synopt: {bf:force}}Allow the output file name to be the same as the name of the input file; overwriting the original do-file. {bf:The use of this option is not recommended} because it is slightly possible that the corrected do-file created by the command will break something in your code and you should always keep a backup of it.{p_end}
-{synopt: {bf:{ul:auto}matic}}Correct all bad coding practices without asking if you want each bad coding practice to be corrected or not.  By default, the command will ask the user about each correction interactively after producing the summary report.{p_end}
+{synopt: {bf:{ul:v}erbose}}Report bad practices and issues found on each line of
+the do-file.{p_end}
+{synopt: {bf:{ul:nosum}mary}}Suppress summary table of bad practices and
+potential issues.{p_end}
+{synopt: {bf:{ul:i}ndent}({it:integer})}Number of whitespaces used when checking
+indentation coding practices (default: 4).{p_end}
+{synopt: {bf:{ul:s}pace}({it:integer})}Number of whitespaces used instead of
+hard tabs when checking indentation practices (default: same as indent).{p_end}
+{synopt: {bf:{ul:l}inemax}({it:integer})}Maximum number of characters in a line
+when checking line extension practices (default: 80).{p_end}
+{synopt: {bf:{ul:e}xcel}({it:filename})}Save an Excel file of line-by-line
+results.{p_end}
+{synopt: {bf:force}}Allow the output file name to be the same as the name of the
+input file; overwriting the original do-file. {bf:The use of this option is not
+recommended} because it is slightly possible that the corrected do-file created
+by the command will break something in your code and you should always keep a
+backup of it.{p_end}
+{synopt: {bf:{ul:auto}matic}}Correct all bad coding practices without asking if
+you want each bad coding practice to be corrected or not.  By default, the
+command will ask the user about each correction interactively after producing
+the summary report.{p_end}
 {synopt: {bf:replace}}Overwrite any existing {it:output} file.{p_end}
 {synoptline}
 
@@ -65,7 +90,8 @@
 {pstd}{bf:Avoid abstract index names}
 {p_end}
 
-{pstd}- In for-loop statements, index names should describe what the code is looping over. For example, avoid writing code like this:
+{pstd}- In for-loop statements, index names should describe what the code is
+looping over. For example, avoid writing code like this:
 {p_end}
 
 {input}{space 8}  foreach i of varlist cassava maize wheat { }
@@ -78,73 +104,90 @@
 {pstd}{bf:Use proper indentations}
 {p_end}
 
-{pstd}- After declaring for-loop statements or if-else statements, add indentation with whitespaces (usually 2 or 4) in the lines inside the loop.
+{pstd}- After declaring for-loop statements or if-else statements, add
+indentation with whitespaces (usually 2 or 4) in the lines inside the loop.
 {p_end}
 
 {pstd}{bf:Use indentations after declaring newline symbols (///)}
 {p_end}
 
-{pstd}- After a new line statement (///), add indentation (usually 2 or 4 whitespaces).
+{pstd}- After a new line statement (///), add indentation (usually 2 or 4
+whitespaces).
 {p_end}
 
 {pstd}{bf:Use the {c 34}!missing(){c 34} function for conditions with missing values}
 {p_end}
 
-{pstd}- For clarity, use {inp:!missing(var)} instead of {inp:var < .} or {inp:var != .} 
+{pstd}- For clarity, use {inp:!missing(var)} instead of {inp:var < .} or
+{inp:var != .}
 {p_end}
 
 {pstd}{bf:Add whitespaces around math symbols (+, =, <, >)}
 {p_end}
 
-{pstd}- For better readability, add whitespaces around math symbols.  For example, do {inp:gen a = b + c if d == e} instead of {inp:gen a=b+c if d==e}. 
+{pstd}- For better readability, add whitespaces around math symbols. For
+example, do {inp:gen a = b + c if d == e} instead of {inp:gen a=b+c if d==e}.
 {p_end}
 
 {pstd}{bf:Specify the condition in an {c 34}if{c 34} statement}
 {p_end}
 
-{pstd}- Always explicitly specify the condition in the if statement.  For example, declare {inp:if var == 1} instead of just using {inp:if var}. 
+{pstd}- Always explicitly specify the condition in the if statement. For
+example, declare {inp:if var == 1} instead of just using {inp:if var}.
 {p_end}
 
-{pstd}{bf:Do not use {c 34}#delimit{c 34}, instead use {c 34}///{c 34} for line breaks}
+{pstd}{bf:Do not use {c 34}#delimit{c 34}, instead use{c 34}///{c 34} for line breaks}
 {p_end}
 
-{pstd}- More information about the use of line breaks {browse "https://worldbank.github.io/dime-data-handbook/coding.html#line-breaks":here}.
+{pstd}- More information about the use of line breaks
+{browse "https://worldbank.github.io/dime-data-handbook/coding.html#line-breaks":here}.
 {p_end}
 
 {pstd}{bf:Do not use cd to change current folder}
 {p_end}
 
-{pstd}- Use absolute and dynamic file paths. More about this {browse "https://worldbank.github.io/dime-data-handbook/coding.html#writing-file-paths":here}.
+{pstd}- Use absolute and dynamic file paths. More about this
+{browse "https://worldbank.github.io/dime-data-handbook/coding.html#writing-file-paths":here}.
 {p_end}
 
 {pstd}{bf:Use line breaks in long lines}
 {p_end}
 
-{pstd}- For lines that are too long, use {inp:///} to divide them into multiple lines.  It is recommended to restrict the number of characters in a line to 80 or less. 
+{pstd}- For lines that are too long, use {inp:///} to divide them into multiple
+lines.  It is recommended to restrict the number of characters in a line to 80
+or less.
 {p_end}
 
 {pstd}{bf:Use curly brackets for global macros}
 {p_end}
 
-{pstd}- Always use {inp:} for global macros.  For example, use {inp:} instead of {inp:}. 
+{pstd}- Always use {inp:} for global macros.  For example, use {inp:} instead
+of {inp:}.
 {p_end}
 
 {pstd}{bf:Include missing values in condition expressions}
 {p_end}
 
-{pstd}- Condition expressions like {inp:var != 0} or {inp:var > 0} are evaluated to true for missing values. Make sure to explicitly take missing values into account by using {inp:missing(var)} in expressions. 
+{pstd}- Condition expressions like {inp:var != 0} or {inp:var > 0} are evaluated
+to true for missing values. Make sure to explicitly take missing values into
+account by using {inp:missing(var)} in expressions.
 {p_end}
 
 {pstd}{bf:Check if backslashes are not used in file paths}
 {p_end}
 
-{pstd}- Check if backslashes {inp:(%} are not used in file paths. If you are using them, then replace them with forward slashes {inp:(/)}. Users should note that the linter might not distinguish perfectly which uses of a backslash are file paths. In general, this flag will come up every time a backslash is used in the same line as a local, glocal, or the cd command. 
+{pstd}- Check if backslashes {inp:(%} are not used in file paths. If you are
+using them, then replace them with forward slashes {inp:(/)}. Users should note
+that the linter might not distinguish perfectly which uses of a backslash are
+file paths. In general, this flag will come up every time a backslash is used in
+the same line as a local, glocal, or the cd command.
 {p_end}
 
 {pstd}{bf:Check if tildes (~) are not used for negations}
 {p_end}
 
-{pstd}- If you are using tildes {inp:(~)} are used for negations, replace them with bangs {inp:(!)}. 
+{pstd}- If you are using tildes {inp:(~)} are used for negations, replace them
+with bangs {inp:(!)}.
 {p_end}
 
 {dlgtab:Correct functionality}
@@ -152,19 +195,27 @@
 {pstd}{bf:Coding practices to be corrected:}
 {p_end}
 
-{pstd}Users should note that the Correct feature does not correct all the bad practices detected.  It only corrects the following:
+{pstd}Users should note that the Correct feature does not correct all the bad
+practices detected.  It only corrects the following:
 {p_end}
 
-{pstd}- Replaces the use of {inp:#delimit} with three forward slashes {inp:(///)} in each line affected by {inp:#delimit} 
+{pstd}- Replaces the use of {inp:#delimit} with three forward slashes
+{inp:(///)} in each line affected by {inp:#delimit}
 {p_end}
 
-{pstd}- Replaces hard tabs with soft spaces (4 by default). The amount of spaces can be set with the {inp:tab_space()} option 
+{pstd}- Replaces hard tabs with soft spaces (4 by default). The amount of spaces
+can be set with the {inp:tab_space()} option
 {p_end}
 
-{pstd}- Indents lines inside curly brackets with 4 spaces by default. The amount of spaces can be set with the {inp:indent()} option 
+{pstd}- Indents lines inside curly brackets with 4 spaces by default. The amount
+of spaces can be set with the {inp:indent()} option
 {p_end}
 
-{pstd}- Breaks long lines into multiple lines. Long lines are considered to have more than 80 characters by default, but this setting can be changed with the option {inp:linemax()}.  Note that lines can only be split in whitespaces that are not inside parentheses, curly brackets, or double quotes. If a line does not have any whitespaces, the linter will not be able to break a long line. 
+{pstd}- Breaks long lines into multiple lines. Long lines are considered to have
+more than 80 characters by default, but this setting can be changed with the
+option {inp:linemax()}.  Note that lines can only be split in whitespaces that
+are not inside parentheses, curly brackets, or double quotes. If a line does not
+have any whitespaces, the linter will not be able to break a long line.
 {p_end}
 
 {pstd}- Adds a whitespace before opening curly brackets, except for globals
@@ -176,22 +227,29 @@
 {pstd}- Removes duplicated blank lines
 {p_end}
 
-{pstd}If the option {inp:automatic} is omitted, Stata will prompt the user to confirm that they want to correct each of these bad practices only in case they are detected.  If none of these are detected, it will show a message saying that none of the bad practices it can correct were detected. 
+{pstd}If the option {inp:automatic} is omitted, Stata will prompt the user to
+confirm that they want to correct each of these bad practices only in case they
+are detected.  If none of these are detected, it will show a message saying that
+none of the bad practices it can correct were detected.
 {p_end}
 
 {title:Examples}
 
-{pstd}The following examples illustrate the basic usage of lint. Additional examples can be found {browse "https://github.com/worldbank/repkit/blob/add-linter/src/vignettes/lint-examples.md":here}
+{pstd}The following examples illustrate the basic usage of lint. Additional
+examples can be found
+{browse "https://github.com/worldbank/repkit/blob/add-linter/src/vignettes/lint-examples.md":here}
 {p_end}
 
 {dlgtab:Detecting bad coding practices}
 
-{pstd}The basic usage is to point to a do-file that requires revision as follows:
+{pstd}The basic usage is to point to a do-file that requires revision as
+follows:
 {p_end}
 
 {input}{space 8}lint "test/bad.do"
 {text}
-{pstd}For the detection feature you can use all the options but {it:automatic}, {it:force}, and {it:replace}, which are part of the correction functionality.
+{pstd}For the detection feature you can use all the options but {it:automatic},
+{it:force}, and {it:replace}, which are part of the correction functionality.
 {p_end}
 
 {pstd}{bf:{ul:Options:}}
@@ -207,17 +265,20 @@
 
 {input}{space 8}lint "test/bad.do", nosummary
 {text}
-{pstd}3. Specify the number of whitespaces used for detecting indentation practices (default: 4):
+{pstd}3. Specify the number of whitespaces used for detecting indentation
+practices (default: 4):
 {p_end}
 
 {input}{space 8}lint "test/bad.do", indent(2)
 {text}
-{pstd}4. Specify the number of whitespaces used instead of hard tabs for detecting indentation practices (default: same value used in indent):
+{pstd}4. Specify the number of whitespaces used instead of hard tabs for
+detecting indentation practices (default: same value used in indent):
 {p_end}
 
 {input}{space 8}lint "test/bad.do", tab_space(6)
 {text}
-{pstd}5. Specify the maximum number of characters in a line allowed when detecting line extension (default: 80):
+{pstd}5. Specify the maximum number of characters in a line allowed when
+detecting line extension (default: 80):
 {p_end}
 
 {input}{space 8}lint "test/bad.do", linemax(100)
@@ -234,7 +295,10 @@
 {text}
 {dlgtab:Correcting bad coding practices}
 
-{pstd}The basic usage of the correction feature requires to specify the input do-file and the output do-file that will have the corrections. If you do not include any options, the linter will ask you confirm if you want a specific bad practice to be corrected for each bad practice detected:
+{pstd}The basic usage of the correction feature requires to specify the input
+do-file and the output do-file that will have the corrections. If you do not
+include any options, the linter will ask you confirm if you want a specific bad
+practice to be corrected for each bad practice detected:
 {p_end}
 
 {pstd}1. Basic correction use (the linter will ask what to correct):
@@ -247,7 +311,8 @@
 
 {input}{space 8}lint "test/bad.do" using "test/bad_corrected.do", automatic
 {text}
-{pstd}3. Use the same name for the output file (note that this will overwrite the input file, this is not recommended):
+{pstd}3. Use the same name for the output file (note that this will overwrite
+the input file, this is not recommended):
 {p_end}
 
 {input}{space 8}lint "test/bad.do" using "test/bad.do", automatic force
@@ -255,11 +320,16 @@
 {pstd}4. Replace the output file if it already exists
 {p_end}
 
-{input}{space 8}lint "test/bad.do" using "test/bad_corrected.do", automatic replace
+{input}{space 8}lint "test/bad.do" using "test/bad_corrected.do", automatic
+replace
 {text}
 {title:Feedback, bug reports and contributions}
 
-{pstd}Read more about these commands on {browse "https://github.com/worldbank/repkit":this repo} where this package is developed. Please provide any feedback by {browse "https://github.com/worldbank/repkit/issues":opening an issue}. PRs with suggestions for improvements are also greatly appreciated.
+{pstd}Read more about these commands on
+{browse "https://github.com/worldbank/repkit":this repo} where this package is
+developed. Please provide any feedback by
+{browse "https://github.com/worldbank/repkit/issues":opening an issue}.
+PRs with suggestions for improvements are also greatly appreciated.
 {p_end}
 
 {title:Authors}

--- a/src/sthlp/lint.sthlp
+++ b/src/sthlp/lint.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.0 20240923}{...}
+{* *! version 3.1 20240926}{...}
 {hline}
 {pstd}help file for {hi:lint}{p_end}
 {hline}

--- a/src/sthlp/repado.sthlp
+++ b/src/sthlp/repado.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.0 20240923}{...}
+{* *! version 3.1 20240926}{...}
 {hline}
 {pstd}help file for {hi:repado}{p_end}
 {hline}

--- a/src/sthlp/repadolog.sthlp
+++ b/src/sthlp/repadolog.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.0 20240923}{...}
+{* *! version 3.1 20240926}{...}
 {hline}
 {pstd}help file for {hi:repadolog}{p_end}
 {hline}

--- a/src/sthlp/repkit.sthlp
+++ b/src/sthlp/repkit.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.0 20240923}{...}
+{* *! version 3.1 20240926}{...}
 {hline}
 {pstd}help file for {hi:repkit}{p_end}
 {hline}

--- a/src/sthlp/reproot.sthlp
+++ b/src/sthlp/reproot.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.0 20240923}{...}
+{* *! version 3.1 20240926}{...}
 {hline}
 {pstd}help file for {hi:reproot}{p_end}
 {hline}

--- a/src/sthlp/reproot_setup.sthlp
+++ b/src/sthlp/reproot_setup.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.0 20240923}{...}
+{* *! version 3.1 20240926}{...}
 {hline}
 {pstd}help file for {hi:reproot_setup}{p_end}
 {hline}

--- a/src/sthlp/reprun.sthlp
+++ b/src/sthlp/reprun.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 3.0 20240923}{...}
+{* *! version 3.1 20240926}{...}
 {hline}
 {pstd}help file for {hi:reprun}{p_end}
 {hline}


### PR DESCRIPTION
Long lines in synopt table broke the rendering. After Speaking with Prof. Baum, administrator of SSC, he recommended shorten all lines such that they are not longer then 80-100 characters.