### PR TITLE
reverted author name in repscan

### DIFF
--- a/src/mdhlp/repscan.md
+++ b/src/mdhlp/repscan.md
@@ -87,7 +87,7 @@ Pull requests with suggestions for improvements or bug fixes are also greatly ap
 
 # Authors
 
-DECDI Analytics, The World Bank (dimeanalytics@worldbank.org).
+DIME Analytics, The World Bank dimeanalytics@worldbank.org
 
 # Acknowledgements
 

--- a/src/sthlp/repscan.sthlp
+++ b/src/sthlp/repscan.sthlp
@@ -105,7 +105,7 @@ Pull requests with suggestions for improvements or bug fixes are also greatly ap
 
 {title:Authors}
 
-{pstd}DECDI Analytics, The World Bank (dimeanalytics@worldbank.org).
+{pstd}DIME Analytics, The World Bank dimeanalytics@worldbank.org
 {p_end}
 
 {title:Acknowledgements}


### PR DESCRIPTION
from DECDI Analytics to DIME Analytics in order not to break the packages by author in SSC stats